### PR TITLE
Bug correction to work with infludb 0.8x

### DIFF
--- a/datasource.js
+++ b/datasource.js
@@ -50,7 +50,7 @@ function (angular, _, dateMath, InfluxSeries, InfluxQueryBuilder) {
   InfluxDatasource.prototype.query = function(options) {
     var timeFilter = getTimeFilter(options);
 
-    var promises = _.map(options.targets, function(target) {
+    var promises = _.map(options.targets, (function(target) {
       if (target.hide || !((target.series && target.column) || target.query)) {
         return [];
       }
@@ -71,7 +71,7 @@ function (angular, _, dateMath, InfluxSeries, InfluxQueryBuilder) {
       var handleResponse = _.partial(handleInfluxQueryResponse, alias, queryBuilder.groupByField);
       return this._seriesQuery(query).then(handleResponse);
 
-    }, this);
+    }).bind(this));
 
     return this.q.all(promises).then(function(results) {
       return { data: _.flatten(results) };

--- a/func_editor.js
+++ b/func_editor.js
@@ -14,7 +14,7 @@ function (angular, _, $) {
                              'data-toggle="dropdown">{{target.function}}</a><span>(</span>';
 
       var paramTemplate = '<input type="text" style="display:none"' +
-                          ' class="input-mini tight-form-func-param"></input>';
+                          ' class="input-mini tight-form-func-param"/>';
 
       return {
         restrict: 'A',
@@ -82,7 +82,7 @@ function (angular, _, $) {
           function addTypeahead($input) {
             $input.attr('data-provide', 'typeahead');
 
-            var skaup = $scope
+            var skaup = $scope;
             $input.typeahead({
               source: function () {
                 return skaup.ctrl.listColumns.apply(null, arguments);

--- a/influx_series.js
+++ b/influx_series.js
@@ -1,5 +1,5 @@
 define([
-  'lodash',
+  'lodash'
 ],
 function (_) {
   'use strict';

--- a/partials/config.html
+++ b/partials/config.html
@@ -9,7 +9,7 @@
 			Database
 		</li>
 		<li>
-			<input type="text" class="tight-form-input input-large" ng-model='ctrl.current.database' placeholder="" required></input>
+			<input type="text" class="tight-form-input input-large" ng-model='ctrl.current.jsonData.database' placeholder="" required/>
 		</li>
 	</ul>
 	<div class="clearfix"></div>
@@ -20,13 +20,13 @@
 			User
 		</li>
 		<li>
-			<input type="text" class="tight-form-input input-large" ng-model='ctrl.current.user' placeholder="" required></input>
+			<input type="text" class="tight-form-input input-large" ng-model='ctrl.current.jsonData.username' placeholder="" required/>
 		</li>
 		<li class="tight-form-item">
 			Password
 		</li>
 		<li>
-			<input type="password" class="tight-form-input input-large" ng-model='ctrl.current.password' placeholder="" required></input>
+			<input type="password" class="tight-form-input input-large" ng-model='ctrl.current.jsonData.password' placeholder="" required/>
 		</li>
 	</ul>
 	<div class="clearfix"></div>

--- a/query_ctrl.js
+++ b/query_ctrl.js
@@ -11,7 +11,7 @@ function (angular, sdk) {
     var self;
 
     function InfluxQueryCtrl08($scope, $injector, $timeout) {
-      _super.call(this, $scope, $injector)
+      _super.call(this, $scope, $injector);
       this.timeout = $timeout;
       this.scope = $scope;
 
@@ -47,7 +47,12 @@ function (angular, sdk) {
       //});
 
       self = this;
-    };
+
+      $scope.seriesBlur = self.seriesBlur;
+      $scope.changeFunction = self.changeFunction;
+      $scope.listColumns = self.listColumns;
+      $scope.listSeries = self.listSeries;
+    }
 
     InfluxQueryCtrl08.prototype = Object.create(_super.prototype);
     InfluxQueryCtrl08.prototype.constructor = InfluxQueryCtrl08;
@@ -55,21 +60,21 @@ function (angular, sdk) {
     InfluxQueryCtrl08.templateUrl = 'public/plugins/grafana-influxdb-08-datasource/partials/query.editor.html';
 
     InfluxQueryCtrl08.prototype.toggleEditorMode = function () {
-      this.target.rawQuery = !this.target.rawQuery;
+      self.target.rawQuery = !self.target.rawQuery;
     };
 
     // Cannot use typeahead and ng-change on blur at the same time
     InfluxQueryCtrl08.prototype.seriesBlur = function() {
-      if (this.oldSeries !== this.target.series) {
-        this.oldSeries = this.target.series;
-        this.columnList = null;
-        this.panelCtrl.refresh();
+      if (self.oldSeries !== self.target.series) {
+        self.oldSeries = self.target.series;
+        self.columnList = null;
+        self.panelCtrl.refresh();
       }
     };
 
     InfluxQueryCtrl08.prototype.changeFunction = function(func) {
-      this.target.function = func;
-      this.panelCtrl.refresh();
+      self.target.function = func;
+      self.panelCtrl.refresh();
     };
 
     // called outside of digest
@@ -90,7 +95,7 @@ function (angular, sdk) {
     InfluxQueryCtrl08.prototype.listSeries = function(query, callback) {
       if (query !== '') {
         seriesList = [];
-        this.datasource.listSeries(query).then(function(series) {
+        self.datasource.listSeries(query).then(function(series) {
           seriesList = series;
           callback(seriesList);
         });


### PR DESCRIPTION
Hi, after some research problem comes from :

configuration error : database, username & password are not take into
account from config partial via ctrl.current.xxx . (Based on grafana
plugins, using ctrl.current.jsonData.xxx do the trick.)
URL should be http://xxxxxx/db/MyDatabase/yyyy as previous post mention.
bs-typeahead does not work since references to function in query_ctrl
are not in scope

Tested on Grafana 3.1.1 with Influxdb 0.8 with direct connection.

![2016-10-20_08-45-14](https://cloud.githubusercontent.com/assets/7194069/19549015/f8e17c10-96a1-11e6-9f46-13e653db5816.png)
