### PR TITLE
Fix: Plugin broken in Grafana 4

### DIFF
--- a/datasource.js
+++ b/datasource.js
@@ -32,7 +32,7 @@ function (angular, _, dateMath, InfluxSeries, InfluxQueryBuilder) {
   InfluxDatasource.prototype.query = function(options) {
     var timeFilter = getTimeFilter(options);
 
-    var promises = _.map(options.targets, function(target) {
+    var promises = _.map(options.targets, (function(target) {
       if (target.hide || !((target.series && target.column) || target.query)) {
         return [];
       }
@@ -53,7 +53,7 @@ function (angular, _, dateMath, InfluxSeries, InfluxQueryBuilder) {
       var handleResponse = _.partial(handleInfluxQueryResponse, alias, queryBuilder.groupByField);
       return this._seriesQuery(query).then(handleResponse);
 
-    }, this);
+    }).bind(this));
 
     return this.q.all(promises).then(function(results) {
       return { data: _.flatten(results) };


### PR DESCRIPTION
The upgrade of Lodash in Grafana 4 broke the plugin, the third argument ('thisArg') to _.map that bound the callbacks this-contex was removed. 

This commit explicitly binds the callback instead.

-- 
For anyone searching for this problem, this is how it apperas in the console:

```
boot.85c49108.js:formatted:44467 TypeError: Cannot read property '_seriesQuery' of undefined
    at eval (datasource.js?bust=1482144303665:54)
    at l (boot.85c49108.js:formatted:61524)
    at Function.Sg [as map] (boot.85c49108.js:formatted:63798)
    at InfluxDatasource.query (datasource.js?bust=1482144303665:35)
    at h.f.issueQueries (boot.85c49108.js:formatted:51727)
    at h.issueQueries (boot.85c49108.js:formatted:23224)
    at g (boot.85c49108.js:formatted:44883)
    at boot.85c49108.js:formatted:44893
    at o.$eval (boot.85c49108.js:formatted:45380)
    at o.$digest (boot.85c49108.js:formatted:45308)
```